### PR TITLE
Models: Use UUID4 as primary keys

### DIFF
--- a/gram/models/models.py
+++ b/gram/models/models.py
@@ -10,16 +10,16 @@ from tortoise.fields import (
     DatetimeField,
     ForeignKeyField,
     ForeignKeyRelation,
-    IntField,
     ReverseRelation,
     TextField,
+    UUIDField,
 )
 from tortoise.models import Model
 from tortoise.validators import MinLengthValidator, RegexValidator
 
 
 class User(Model):
-    id = IntField(pk=True)
+    id = UUIDField(pk=True)
     created_at = DatetimeField(auto_now_add=True)
     modified_at = DatetimeField(auto_now=True)
     username = CharField(
@@ -79,7 +79,7 @@ class User(Model):
 
 
 class Post(Model):
-    id = IntField(pk=True)
+    id = UUIDField(pk=True)
     created_at = DatetimeField(auto_now_add=True)
     modified_at = DatetimeField(auto_now=True)
     title = CharField(
@@ -112,7 +112,7 @@ class Post(Model):
 
 
 class Comment(Model):
-    id = IntField(pk=True)
+    id = UUIDField(pk=True)
     created_at = DatetimeField(auto_now_add=True)
     modified_at = DatetimeField(auto_now=True)
     content = TextField()

--- a/gram/routes/comments.py
+++ b/gram/routes/comments.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi_limiter.depends import RateLimiter
 from tortoise.contrib.fastapi import HTTPNotFoundError
@@ -22,7 +24,7 @@ router = APIRouter(prefix="/comments", tags=["comments"])
     dependencies=[Depends(RateLimiter(times=5, minutes=1))],
 )
 async def create_post_comment(
-    post_id: int,
+    post_id: UUID,
     comment: PydanticCommentCreate,
     user: User = Depends(current_user),
 ):
@@ -46,8 +48,8 @@ async def create_post_comment(
     dependencies=[Depends(RateLimiter(times=1, seconds=10))],
 )
 async def update_post_comment(
-    post_id: int,
-    comment_id: int,
+    post_id: UUID,
+    comment_id: UUID,
     updated_comment: PydanticCommentUpdate,
     user: User = Depends(current_user),
 ):
@@ -80,8 +82,8 @@ async def update_post_comment(
     dependencies=[Depends(RateLimiter(times=5, minutes=1))],
 )
 async def delete_post_comment(
-    post_id: int,
-    comment_id: int,
+    post_id: UUID,
+    comment_id: UUID,
     user: User = Depends(current_user),
 ):
     post_record = await Post.get(id=post_id)
@@ -103,7 +105,7 @@ async def delete_post_comment(
     response_model=list[PydanticComment],
     responses={404: {"model": HTTPNotFoundError}},
 )
-async def get_post_comments(post_id: int):
+async def get_post_comments(post_id: UUID):
     post_record = await Post.get(id=post_id)
     return await PydanticComment.from_queryset(Comment.filter(post=post_record))
 
@@ -113,7 +115,7 @@ async def get_post_comments(post_id: int):
     response_model=PydanticComment,
     responses={404: {"model": HTTPNotFoundError}},
 )
-async def get_post_comment(post_id: int, comment_id: int):
+async def get_post_comment(post_id: UUID, comment_id: UUID):
     post_record = await Post.get(id=post_id)
     return await PydanticComment.from_queryset_single(
         Comment.filter(id=comment_id, post=post_record)

--- a/gram/routes/posts.py
+++ b/gram/routes/posts.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi_limiter.depends import RateLimiter
 from tortoise.contrib.fastapi import HTTPNotFoundError
@@ -44,7 +46,7 @@ async def create_post(
     dependencies=[Depends(RateLimiter(times=1, seconds=10))],
 )
 async def update_post(
-    post_id: int,
+    post_id: UUID,
     updated_post: PydanticPostUpdate,
     user: User = Depends(current_user),
 ):
@@ -69,7 +71,7 @@ async def update_post(
     },
     dependencies=[Depends(RateLimiter(times=5, minutes=1))],
 )
-async def delete_post(post_id: int, user: User = Depends(current_user)):
+async def delete_post(post_id: UUID, user: User = Depends(current_user)):
     post_record = await Post.get(id=post_id).prefetch_related("author")
     if not user == post_record.author:
         raise HTTPException(
@@ -87,5 +89,5 @@ async def delete_post(post_id: int, user: User = Depends(current_user)):
     response_model=PydanticPost,
     responses={404: {"model": HTTPNotFoundError}},
 )
-async def get_post(post_id: int):
+async def get_post(post_id: UUID):
     return await PydanticPost.from_queryset_single(Post.get(id=post_id))

--- a/gram/routes/users.py
+++ b/gram/routes/users.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import UUID
 
 from fastapi import APIRouter, Depends
 from fastapi_limiter.depends import RateLimiter
@@ -63,11 +64,11 @@ async def get_logged_in_user_posts(user: User = Depends(current_user)):
 
 
 @router.get("/{user_id}", response_model=PydanticUser)
-async def get_user(user_id: int):
+async def get_user(user_id: UUID):
     return await PydanticUser.from_queryset_single(User.get(id=user_id))
 
 
 @router.get("/{user_id}/posts", response_model=list[PydanticPost])
-async def get_user_posts(user_id: int):
+async def get_user_posts(user_id: UUID):
     user_record = await User.get(id=user_id)
     return await PydanticPost.from_queryset(Post.filter(author=user_record))


### PR DESCRIPTION
Using UUIDs instead of standard autoincremented int makes it harder for users to pull all data from the API. This approach feels more secure than autoincrement IDs.